### PR TITLE
fix(deps): bump quote minimal version to 0.6.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "0.4"
-quote = "0.6"
+quote = "0.6.8"
 syn = "0.15"


### PR DESCRIPTION
In the current state, the package fails to build with `-Zminimal-versions`. Due to a requirement of quote `0.6.8` which right now is defined as `0.6` in `Cargo.toml`.

The problem with this is that it will fail all `-Zminimal-versions` for all (transient) dependents.

This is a quick and a no-risk fix. However, it's probably a good idea to move to the `1.x.y` version of the dependencies.

Lastly, it might seem like a very unused repository considering it has a single star on GitHub, but there are a couple of medium-sized packages that depend on it now. :)